### PR TITLE
Refactor 'jade' to 'pug'

### DIFF
--- a/semi-static.js
+++ b/semi-static.js
@@ -12,7 +12,7 @@ function defaults(config) {
         ret.folderPath = path.dirname(require.main.filename) + "/views/static";
     }
 
-    ret.fileExt = config.fileExt != null ? config.fileExt : "jade";
+    ret.fileExt = config.fileExt != null ? config.fileExt : "pug";
     ret.root = config.root != null ? config.root : "/";
     ret.passReq = !!config.passReq;
     ret.context = config.context;


### PR DESCRIPTION
With the update in ExpressJS to use Pug over Jade, refactor this to accommodate the new default.